### PR TITLE
updated: directly send mime type email to avoid lettre double encodin…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -196,7 +202,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20b9cde6a71f9f758440470f3de16db6c09a02c443ce66850d87f5410548fb8e"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "memchr",
 ]
 
@@ -546,7 +552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "759bc2b8eabb6a30b235d6f716f7f36479f4b38cbe65b8747aefee51f89e8437"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chumsky",
  "email-encoding",
  "email_address",
@@ -601,6 +607,7 @@ name = "mail-sender"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "base64 0.21.7",
  "dotenv",
  "http",
  "lettre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ lettre = { version = "0.11.15", default-features = false, features = [
     "tokio1",
     "tokio1-rustls-tls"
 ] }
+base64 = "0.21"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 http = "1.3.1"


### PR DESCRIPTION
 directly send mime type email to avoid lettre double encoding correctly formated emails